### PR TITLE
Proximityhash import feature

### DIFF
--- a/proximityhash.py
+++ b/proximityhash.py
@@ -83,7 +83,7 @@ def create_geohash(latitude, longitude, radius, precision, georaptor_flag=False,
         geohashes += [Geohash.encode(point[0], point[1], precision)]
 
     if georaptor_flag:
-        georaptor_out = georaptor.compress(geohashes, int(minlevel), int(maxlevel))
+        georaptor_out = georaptor.compress(set(geohashes), int(minlevel), int(maxlevel))
         if __name__ != '__main__':
             return georaptor_out
         return ','.join(georaptor_out)

--- a/proximityhash.py
+++ b/proximityhash.py
@@ -83,10 +83,14 @@ def create_geohash(latitude, longitude, radius, precision, georaptor_flag=False,
         geohashes += [Geohash.encode(point[0], point[1], precision)]
 
     if georaptor_flag:
-        georaptor_out = georaptor.compress(set(geohashes), int(minlevel), int(maxlevel))
+        georaptor_out = georaptor.compress(geohashes, int(minlevel), int(maxlevel))
+        if __name__ != '__main__':
+            return georaptor_out
         return ','.join(georaptor_out)
 
     else:
+        if __name__ != '__main__':
+            return set(geohashes)
         return ','.join(set(geohashes))
 
 

--- a/test/test_proximityhash.py
+++ b/test/test_proximityhash.py
@@ -30,9 +30,9 @@ class latlon_convert_test_case(unittest.TestCase):
 class create_geohash_test_case(unittest.TestCase):
     """Tests for `create_geohash`."""
     def test_create_geohash(self):
-        expected = 'tdnu20t9,tdnu20t8,tdnu20t3,tdnu20t2,tdnu20mz,tdnu20mx,tdnu20tc,tdnu20tb,tdnu20td,tdnu20tf'
+        expected = ['tdnu20t9','tdnu20t8','tdnu20t3','tdnu20t2','tdnu20mz','tdnu20mx','tdnu20tc','tdnu20tb','tdnu20td','tdnu20tf']
         output = proximityhash.create_geohash(12.0, 77.0, 20.0, 8, georaptor_flag=False, minlevel=1, maxlevel=12)
-        self.assertEqual(output, expected)
+        self.assertTrue(set(expected) == output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When proximityhash is imported in another program, create_geohash() will now return the geohashes as a set instead of converting it to a string for output.  This should make it easier to use as a feature of other software.

Also changes tests to compare sets instead of strings, so tests won't fail based on the order geohashes are returned in. 